### PR TITLE
List from L&A

### DIFF
--- a/cms/schemas/documents/about.ts
+++ b/cms/schemas/documents/about.ts
@@ -13,33 +13,7 @@ const about: SchemaTypeDefinition = {
     {
       title: 'Contact',
       name: 'contact',
-      type: 'array',
-      of: [
-        {
-          type: 'object',
-          fields: [
-            {
-              title: 'Label',
-              name: 'label',
-              type: 'string',
-            },
-            {
-              title: 'Link Text',
-              name: 'link_label',
-              type: 'string',
-            },
-            {
-              title: 'URL',
-              name: 'url',
-              type: 'url',
-              validation: (Rule) =>
-                Rule.uri({
-                  scheme: ['http', 'https', 'mailto', 'tel'],
-                }),
-            },
-          ],
-        },
-      ],
+      type: 'content',
     },
     {
       title: 'Addresses',

--- a/web/src/components/modules/CarouselModule.svelte
+++ b/web/src/components/modules/CarouselModule.svelte
@@ -308,6 +308,10 @@ on:enter={() => {
   }
 }
 
+.slide-caption {
+    display: none;
+}
+
 /* Tablet */
 @media (min-width: 800px) {
   .slide {
@@ -315,6 +319,10 @@ on:enter={() => {
   }
   .carousel-section {
     max-width: calc(var(--tablet-width-max) - var(--half-space));
+  }
+
+  .slide-caption {
+    display: block;
   }
 }
 
@@ -326,6 +334,9 @@ on:enter={() => {
   .carousel-section {
     max-width: calc(var(--desktop-width-max) - var(--half-space));
   }
+  .slide-caption {
+    display: block;
+  }
 }
 
 /* Desktop */
@@ -335,6 +346,9 @@ on:enter={() => {
   }
   .carousel-section {
     max-width: calc(var(--large-desktop-width-max) - var(--half-space));
+  }
+  .slide-caption {
+    display: block;
   }
 }
 
@@ -354,6 +368,9 @@ on:enter={() => {
 
   .custom-arrow-prev {
     width: 15%;
+  }
+  .slide-caption {
+    display: block;
   }
 }
 </style>

--- a/web/src/components/modules/CarouselModule.svelte
+++ b/web/src/components/modules/CarouselModule.svelte
@@ -213,6 +213,7 @@ on:enter={() => {
   overflow: hidden;
   position: relative;
   max-height: var(--mobile-height-max); /* Caps the maximum height */
+  align-content: end;
 }
 
 .custom-arrow {

--- a/web/src/components/modules/GridCarouselModule.svelte
+++ b/web/src/components/modules/GridCarouselModule.svelte
@@ -45,7 +45,7 @@
 
 	  // Remove 4px if there is only one item
 	  if (module.items.length === 1) {
-		currentPresetSize = `calc(${currentPresetSize} - 4px)`;
+		currentPresetSize = `calc(${currentPresetSize} - 0px)`;
 	  }
 	}
   

--- a/web/src/components/modules/GridModule.svelte
+++ b/web/src/components/modules/GridModule.svelte
@@ -56,7 +56,7 @@
 
 	  // Remove 4px if there is only one item
 	  if (module.items.length === 1) {
-		currentPresetSize = `calc(${currentPresetSize} - 4px)`;
+		currentPresetSize = `calc(${currentPresetSize} - 1.3rem)`;
 	  }
 	}
   

--- a/web/src/routes/info/+page.svelte
+++ b/web/src/routes/info/+page.svelte
@@ -44,14 +44,7 @@
 		<h2 class="section-title" id="section_title">Contact</h2>
 		<div class="contact-section">
 			{#if about.contact}
-				<div class="email-section">
-					{#each about.contact as contact}
-						<div class="email-container">
-							<h3 class="email-label">{contact.label}:</h3>
-							<a class="email-link" href={contact.url} target="_blank" rel="noreferrer">{contact.link_label}</a>
-						</div>
-					{/each}
-				</div>
+				<Content value={about.contact} />
 			{/if}
 			{#if about.addresses}
 				<div class="address-section" id="addresses">
@@ -231,17 +224,13 @@ section h3 {
 	gap: 2px;
 }
 
-.email-container a {
+:global(.content p a) {
+	font-family: var(--font-serif-italic);
 	text-decoration: none;
 }
 
-.email-container a:hover {
+:global(.content p a:hover){
 	color: var(--red);
-}
-
-.email-link {
-	font-family: var(--font-serif-italic);
-	line-height: 105%;
 }
 
 .address-section {


### PR DESCRIPTION
**Fixes:** 

01. Desktop some image carousel edges still shifting
macOS Monterey 12.6.5: Chrome & Safari

02. Desktop Italic links sitting slightly above the baseline
macOS Monterey 12.6.5: Chrome & Safari

03. Mobile typesetting glitch (Wylie Agency link)
iPhone XR iOS 17.6.1: Chrome & Safari