### PR TITLE
fix 05 and 06

### DIFF
--- a/web/src/components/VideoPlayer.svelte
+++ b/web/src/components/VideoPlayer.svelte
@@ -238,7 +238,7 @@ onMount(() => {
         display: inline-flex;
         justify-content: flex-start; /* Centers the video/image horizontally */
         max-height: var(--mobile-height-max) !important;
-        max-width: var(--mobile-width-max);
+        max-width: 100%;
     }
 
     .video-container {


### PR DESCRIPTION
05. Mobile films surpassing margin
Screenshots included in the link to show this.
iPhone XR iOS 17.6.1: Chrome & Safari

06. Mobile some pages type gets smaller and line doesn't extend to edge
It feels like this is to do with the issue of the films surpassing the margins. The pages with this issue seem to zoom out which means the type is smaller and the line doesn’t reach the edge of the screen.
iPhone XR iOS 17.6.1: Chrome & Safari